### PR TITLE
Add open/close price fields to futures env

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,7 +87,14 @@ def build_states_for_futures_env(df_chunk):
             row.sin_weekday, row.cos_weekday,
             # plus all tb_* and wd_* one-hots…
         ]
-        states.append(TimeSeriesState(ts=row.date_time, price=row.Close, features=feats))
+        states.append(
+            TimeSeriesState(
+                ts=row.date_time,
+                open_price=row.Open,
+                close_price=row.Close,
+                features=feats,
+            )
+        )
     return states
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/main_debug.py
+++ b/main_debug.py
@@ -18,18 +18,24 @@ def build_states_for_futures_env(df):
     Convert each row of df into a TimeSeriesState.
     Here we define the 'features' that the agent will see.
     For instance, we'll use [Open, High, Low, Close, Volume, return, ma_10].
-    We also pick 'date_time' as ts, and 'Close' as price (or you might pick something else).
+    We store both open and close prices separately for each TimeSeriesState.
     """
     states = []
     for i, row in df.iterrows():
         ts = row['date_time']
-        price = float(row['Close'])
+        open_price = float(row['Open'])
+        close_price = float(row['Close'])
         features = [
             row['Open'], row['High'], row['Low'],
             row['Close'], row['Volume'], row['return'],
             row['ma_10']
         ]
-        s = TimeSeriesState(ts=ts, price=price, features=features)
+        s = TimeSeriesState(
+            ts=ts,
+            open_price=open_price,
+            close_price=close_price,
+            features=features,
+        )
         states.append(s)
     return states
 


### PR DESCRIPTION
## Summary
- extend `TimeSeriesState` to keep open/close prices
- execute trades at the next bar's open
- update reward logic to use close prices
- adapt environment builders in `main.py` and `main_debug.py`

## Testing
- `python -m py_compile futures_env.py main.py main_debug.py ga_policy_evolution.py policy_gradient_methods.py trading_environment.py data_preprocessing.py utils.py originalSample.py`

------
https://chatgpt.com/codex/tasks/task_e_683d3535bc6c8325b6919ac9899b3738