### PR TITLE
Improve trading env and trajectory handling

### DIFF
--- a/futures_env.py
+++ b/futures_env.py
@@ -69,6 +69,8 @@ class FuturesEnv(gym.Env):
         self.limit = len(states)
         self.value_per_tick = value_per_tick
         self.tick_size = tick_size
+        if self.value_per_tick <= 0 or self.tick_size <= 0:
+            raise ValueError("value_per_tick and tick_size must be positive")
         self.fill_probability = fill_probability
         self.execution_cost_per_order = execution_cost_per_order
         self.contracts_per_trade = contracts_per_trade
@@ -120,7 +122,10 @@ class FuturesEnv(gym.Env):
         """
         # Reset all internal trackers
         self.done = False
-        self.current_index = 0
+        start_idx = 0
+        if self.limit > 1:
+            start_idx = np.random.randint(0, self.limit - 1)
+        self.current_index = start_idx
         self.current_position = 0
         self.last_position = 0
         self.entry_time = None
@@ -133,14 +138,14 @@ class FuturesEnv(gym.Env):
         self.orders.clear()
         self.trades.clear()
         self.episode += 1
-        self.last_ts = self.states[0].ts if self.limit > 0 else None
+        self.last_ts = self.states[start_idx].ts if self.limit > 0 else None
 
         if self.limit == 0:
             # no data case
             return np.zeros(self.observation_space.shape, dtype=np.float32)
 
         # build a fresh obs from base features + zeros for extras
-        base = self.states[0].features  # length=7
+        base = self.states[start_idx].features  # length=7
         if self.add_current_position_to_state:
             extras = np.zeros(3, dtype=np.float32)
             return np.concatenate([base, extras])
@@ -178,10 +183,14 @@ class FuturesEnv(gym.Env):
         self.current_index += 1
 
         # Handle BUY/SELL actions at the next bar's open
+        high_p = next_state.features[1]
+        low_p = next_state.features[2]
+        volume = next_state.features[4] if len(next_state.features) > 4 else None
+
         if action == 0:
-            self._handle_buy(next_state)
+            self._handle_buy(next_state, high_p, low_p, volume)
         elif action == 2:
-            self._handle_sell(next_state)
+            self._handle_sell(next_state, high_p, low_p, volume)
 
         # compute reward from this time-step
         reward = self._get_reward(self.states[self.current_index])
@@ -209,14 +218,17 @@ class FuturesEnv(gym.Env):
 
         return obs, reward, self.done, info
 
-    def _handle_buy(self, state):
+    def _handle_buy(self, state, high_price, low_price, volume=None):
         """
         Open/close long positions.
         """
         if self.current_position == -1:
             self._close_short(state)
         elif self.current_position == 0:
-            filled_price = self._simulate_fill(state.open_price, 1)
+            filled_price = self._simulate_fill(
+                state.open_price, 1,
+                high_price=high_price, low_price=low_price, volume=volume
+            )
             self.entry_time = state.ts
             self.entry_price = filled_price
             self.entry_cost = self.execution_cost_per_order * self.contracts_per_trade
@@ -224,14 +236,17 @@ class FuturesEnv(gym.Env):
             self.orders.append([str(uuid4()), str(state.ts), filled_price, 1])
             self.current_position = 1
 
-    def _handle_sell(self, state):
+    def _handle_sell(self, state, high_price, low_price, volume=None):
         """
         Open/close short positions.
         """
         if self.current_position == 1:
             self._close_long(state)
         elif self.current_position == 0:
-            filled_price = self._simulate_fill(state.open_price, -1)
+            filled_price = self._simulate_fill(
+                state.open_price, -1,
+                high_price=high_price, low_price=low_price, volume=volume
+            )
             self.entry_time = state.ts
             self.entry_price = filled_price
             self.entry_cost = self.execution_cost_per_order * self.contracts_per_trade
@@ -239,7 +254,14 @@ class FuturesEnv(gym.Env):
             self.orders.append([str(uuid4()), str(state.ts), filled_price, -1])
             self.current_position = -1
 
-    def _simulate_fill(self, price: float, trade_type: int) -> float:
+    def _simulate_fill(
+        self,
+        price: float,
+        trade_type: int,
+        high_price: float | None = None,
+        low_price: float | None = None,
+        volume: float | None = None,
+    ) -> float:
         """
         Simulate slippage, half‐spread cost, and fill probability.
         """
@@ -255,13 +277,22 @@ class FuturesEnv(gym.Env):
             else:
                 slippage = np.random.choice(self.short_values, p=self.short_probabilities)
 
-        # 3) Apply half the bid‐ask spread in the direction of the trade
+        # 3) Apply half the bid-ask spread in the direction of the trade
         spread_adj = (self.bid_ask_spread / 2.0) * (1 if trade_type == 1 else -1)
 
-        # 4) Combine into a raw execution price
-        raw_price = price + slippage + spread_adj
+        # 4) Volume-based scaling of slippage
+        volume_scale = 1.0
+        if volume is not None and volume > 0:
+            volume_scale += 1.0 / (volume + 1e-8)
 
-        # 5) Round to the nearest tick increment
+        # 5) Combine all components
+        raw_price = price + (slippage + spread_adj) * volume_scale
+
+        # 6) Clip to high/low range if provided
+        if high_price is not None and low_price is not None:
+            raw_price = np.clip(raw_price, low_price, high_price)
+
+        # 7) Round to the nearest tick increment
         return round_to_nearest_increment(raw_price, self.tick_size)
 
     def _get_reward(self, state):
@@ -299,7 +330,11 @@ class FuturesEnv(gym.Env):
         Close an existing long position.
         """
         self.exit_time = state.ts
-        self.exit_price = self._simulate_fill(state.open_price, -1)
+        self.exit_price = self._simulate_fill(
+            state.open_price, -1,
+            high_price=state.features[1], low_price=state.features[2],
+            volume=state.features[4] if len(state.features) > 4 else None
+        )
         price_diff = self.exit_price - self.entry_price
         ticks = price_diff / self.tick_size
         pnl = ticks * self.value_per_tick * self.contracts_per_trade
@@ -316,7 +351,11 @@ class FuturesEnv(gym.Env):
         Close an existing short position.
         """
         self.exit_time = state.ts
-        self.exit_price = self._simulate_fill(state.open_price, 1)
+        self.exit_price = self._simulate_fill(
+            state.open_price, 1,
+            high_price=state.features[1], low_price=state.features[2],
+            volume=state.features[4] if len(state.features) > 4 else None
+        )
         price_diff = self.entry_price - self.exit_price
         ticks = price_diff / self.tick_size
         pnl = ticks * self.value_per_tick * self.contracts_per_trade


### PR DESCRIPTION
## Summary
- allow PPO rollout collection to track final env state
- assert tick size and value per tick positive
- randomize start index on env reset
- use high/low price data for order fill logic and include volume-based slippage

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684d122615188325be95751d879b88fd