### PR TITLE
Fix features for FuturesEnv

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -177,11 +177,16 @@ def scale_and_split_gpu(
     # Drop rows with NaN in numeric columns
     df = df.dropna(subset=numeric_cols).reset_index(drop=True)
 
+    # Preserve raw OHLCV columns for the trading environment
+    raw_cols = ["Open", "High", "Low", "Close", "Volume"]
+    for col in raw_cols:
+        df[f"{col}_raw"] = df[col].astype("float64")
+
     X = df[numeric_cols]
     scaler = CuStandardScaler()
     X_scaled = scaler.fit_transform(X)
 
-    # Replace in-place
+    # Replace in-place with scaled values
     df[numeric_cols] = X_scaled
 
     # Split on-GPU

--- a/main.py
+++ b/main.py
@@ -83,17 +83,17 @@ def build_states_for_futures_env(df_chunk):
             row.sin_time, row.cos_time,
             row.sin_weekday, row.cos_weekday,
         ]
-        states.append(
-            TimeSeriesState(
-                ts=row.date_time,
-                open_price=row.Open,
-                close_price=row.Close,
-                features=feats,
-            )
-        )
         for col in df_chunk.columns:
             if col.startswith("tb_") or col.startswith("wd_"):
                 feats.append(getattr(row, col))
+        states.append(
+            TimeSeriesState(
+                ts=row.date_time,
+                open_price=getattr(row, "Open_raw", row.Open),
+                close_price=getattr(row, "Close_raw", row.Close),
+                features=feats,
+            )
+        )
     return states
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -195,6 +195,9 @@ def process_live_row(bar: dict) -> "cudf.DataFrame":
         "volatility": vol,     "sin_time": sin_t,
         "cos_time": cos_t,     "sin_weekday": sin_w,
         "cos_weekday": cos_w,
+        "Open_raw": bar["Open"], "High_raw": bar["High"],
+        "Low_raw": bar["Low"],   "Close_raw": close,
+        "Volume_raw": bar["Volume"],
         **ohe
     }
 


### PR DESCRIPTION
## Summary
- construct state features with one-hot columns before creating `TimeSeriesState`
- preserve unscaled OHLCV prices for trade simulation
- use raw prices for entry/exit values when building `TimeSeriesState`
- include raw values in live inference rows

## Testing
- `python -m py_compile futures_env.py policy_gradient_methods.py main.py`
- `python - <<'PY'
from futures_env import FuturesEnv, TimeSeriesState
from datetime import datetime
import numpy as np
state_features=[1]*16
states=[TimeSeriesState(datetime(2024,1,1),100,100,state_features)]
env=FuturesEnv(states,value_per_tick=10,tick_size=0.25)
obs=env.reset()
print('obs', obs)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684cd3d1de6c8325bfefad217061c73d