### PR TITLE
Refactor logging for single rotating file

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -27,11 +27,7 @@ from cuml.model_selection import train_test_split
 # ──────────────────────────────────────────────────────────────────────────────
 # Logger setup
 # ──────────────────────────────────────────────────────────────────────────────
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s ─ %(message)s",
-    level=logging.INFO
-)
-logger = logging.getLogger("data_prep")
+logger = logging.getLogger(__name__)
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Constants & Defaults

--- a/policy_gradient_methods.py
+++ b/policy_gradient_methods.py
@@ -31,10 +31,6 @@ from utils import evaluate_agent_distributed, compute_performance_metrics
 # Set up logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-if not logger.handlers:
-    ch = logging.StreamHandler()
-    ch.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
-    logger.addHandler(ch)
 
 
 class ActorCriticNet(nn.Module):


### PR DESCRIPTION
## Summary
- centralize logging via rotating file handler
- simplify loggers in policy and data preprocessing modules

## Testing
- `python -m py_compile main.py policy_gradient_methods.py data_preprocessing.py`

------
https://chatgpt.com/codex/tasks/task_e_684f8f421a6c8325ab7438ba52579b31