### PR TITLE
Add Sharpe-based GA fitness

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,7 +296,8 @@ def main():
             train_env, population_size=80, generations=100,
             tournament_size=7, mutation_rate=0.8, mutation_scale=1.0,
             num_workers=4, device=str(device),
-            model_save_path=ga_model
+            model_save_path=ga_model,
+            fitness_metric="sharpe"
         )
         logging.info(f"GA training complete – best fitness: {best_fit:.2f}")
         best_agent.save_model(ga_model)


### PR DESCRIPTION
## Summary
- implement optional Sharpe ratio based fitness in GA
- pass new `fitness_metric` argument through GA evaluation
- use Sharpe-based metric when running GA in `main.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684fba0993248325b1802464f646327e